### PR TITLE
Add certificate generation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Command line installation steps:
         git clone https://github.com/JBEI/ice.git ./ice
         cd ice
 
-* Generate a self-signed certificate
+* Generate a self-signed certificate. When prompted for a password, use **changeit**.
 
         keytool -genkey -alias tomcat -keyalg RSA -keystore ./.keystore
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Command line installation steps:
 
 * Generate a self-signed certificate
 
+        keytool -genkey -alias tomcat -keyalg RSA -keystore ./.keystore
+
 * Start the built in jetty server. This may take a few minutes to download additional dependencies.
         
         mvn jetty:run


### PR DESCRIPTION
I added the command from the [quick install guide](http://ice.jbei.org/install/index.html) 