### PR TITLE
Split lucene permissions across multiple fields

### DIFF
--- a/src/main/java/org/jbei/ice/lib/access/PermissionEntryBridge.java
+++ b/src/main/java/org/jbei/ice/lib/access/PermissionEntryBridge.java
@@ -10,36 +10,45 @@ import org.jbei.ice.storage.model.Permission;
  * {@link org.jbei.ice.storage.hibernate.filter.EntrySecurityFilterFactory}
  *
  * @author Hector Plahar
+ * @author William Morrell
  */
 public class PermissionEntryBridge implements FieldBridge {
 
     @Override
     public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
-        if (value == null)
+        if (value == null) {
             return;
+        }
 
         Permission permission = (Permission) value;
-        if (permission.getEntry() == null && permission.getFolder() == null)
+        if (permission.getEntry() == null && permission.getFolder() == null) {
             return;
+        }
 
         String fieldName;
         if (permission.isCanRead() || permission.isCanWrite()) {
-            fieldName = "canRead";
-        } else
+            fieldName = "canRead_";
+        } else {
+            // doing nothing if no read or write permission
             return;
+        }
 
         // account
         if (permission.getAccount() != null) {
-            String existingFieldValue = document.get(fieldName);
-            if (!permission.getAccount().getEmail().equalsIgnoreCase(existingFieldValue))
-                luceneOptions.addFieldToDocument(fieldName, permission.getAccount().getEmail(), document);
+            String email = permission.getAccount().getEmail();
+            String existingFieldValue = document.get(fieldName + email);
+            if (!email.equalsIgnoreCase(existingFieldValue)) {
+                luceneOptions.addFieldToDocument(fieldName + email, email, document);
+            }
         }
 
         // group
         if (permission.getGroup() != null) {
-            String existingFieldValue = document.get(fieldName);
-            if (!permission.getGroup().getUuid().equalsIgnoreCase(existingFieldValue))
-                luceneOptions.addFieldToDocument(fieldName, permission.getGroup().getUuid(), document);
+            String groupId = permission.getGroup().getUuid();
+            String existingFieldValue = document.get(fieldName + groupId);
+            if (!groupId.equalsIgnoreCase(existingFieldValue)) {
+                luceneOptions.addFieldToDocument(fieldName + groupId, groupId, document);
+            }
         }
 
         // TODO: adding entries to a folder that has permission granted to someone does not trigger this

--- a/src/main/java/org/jbei/ice/storage/hibernate/filter/EntrySecurityFilterFactory.java
+++ b/src/main/java/org/jbei/ice/storage/hibernate/filter/EntrySecurityFilterFactory.java
@@ -5,15 +5,16 @@ import org.apache.lucene.search.*;
 import org.hibernate.search.annotations.Factory;
 import org.hibernate.search.filter.impl.CachingWrapperFilter;
 
-import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Hector Plahar
+ * @author William Morrell
  */
 public class EntrySecurityFilterFactory {
 
     private String accountId;
-    private HashSet<String> groupUUids;
+    private Set<String> groupUUids;
 
     // injected parameter
     public void setAccount(String accountId) {
@@ -21,7 +22,7 @@ public class EntrySecurityFilterFactory {
     }
 
     // injected parameter
-    public void setGroupUUids(HashSet<String> groupUUids) {
+    public void setGroupUUids(Set<String> groupUUids) {
         this.groupUUids = groupUUids;
     }
 
@@ -31,12 +32,14 @@ public class EntrySecurityFilterFactory {
 
         // must have either account id present or group uuid present
         if (accountId != null) {
-            builder.add(new TermQuery(new Term("canRead", accountId)), BooleanClause.Occur.SHOULD);
+            Term accountTerm = new Term("canRead_" + accountId, accountId);
+            builder.add(new TermQuery(accountTerm), BooleanClause.Occur.SHOULD);
         }
 
         if (this.groupUUids != null) {
             for (String uuid : this.groupUUids) {
-                builder.add(new TermQuery(new Term("canRead", uuid)), BooleanClause.Occur.SHOULD);
+                Term groupTerm = new Term("canRead_" + uuid, uuid);
+                builder.add(new TermQuery(groupTerm), BooleanClause.Occur.SHOULD);
             }
         }
 


### PR DESCRIPTION
The existing code was setting a singular permissions field of "canRead"
and only the final value was put in the index. The updated code adds a
field for every user and group with read access.