### PR TITLE
Prevent stack overflow in error email handler

### DIFF
--- a/src/main/java/org/jbei/ice/lib/common/logging/Logger.java
+++ b/src/main/java/org/jbei/ice/lib/common/logging/Logger.java
@@ -34,6 +34,10 @@ public class Logger {
         LOGGER.error(e.getMessage(), e);
     }
 
+    public static void errorLocalOnly(final Throwable t) {
+        LOGGER.error(t.getMessage(), t);
+    }
+
     public static boolean isDebugEnabled() {
         return LOGGER.isDebugEnabled();
     }

--- a/src/main/java/org/jbei/ice/lib/email/CustomEmail.java
+++ b/src/main/java/org/jbei/ice/lib/email/CustomEmail.java
@@ -38,7 +38,8 @@ public class CustomEmail extends Email {
             email.send();
             return true;
         } catch (EmailException e) {
-            Logger.error(e);
+            // local-only error log, prevent stack overflow when failing to send mail
+            Logger.errorLocalOnly(e);
             return false;
         }
     }


### PR DESCRIPTION
The Logger class will send emails to the instance admin for all calls to
Logger.error(). If there is an error in sending this email, there is an
infinite recursion loop ending with a stack overflow. Modify the Logger
class to add a Logger.errorLocalOnly() call that will *not* send an email.
The CustomEmail class will use this local-only handler when encountering
an error sending mail, eliminating the infinite recursion.