### PR TITLE
Change ExceptionMapper to not email on every 404

### DIFF
--- a/src/main/java/org/jbei/ice/services/rest/ICEExceptionMapper.java
+++ b/src/main/java/org/jbei/ice/services/rest/ICEExceptionMapper.java
@@ -11,6 +11,7 @@ import javax.ws.rs.ext.Provider;
  * Exception mapper for mapping exceptions to {@link Response}s
  *
  * @author Hector Plahar
+ * @author William Morrell
  */
 @Provider
 public class ICEExceptionMapper implements ExceptionMapper<Exception> {
@@ -25,8 +26,33 @@ public class ICEExceptionMapper implements ExceptionMapper<Exception> {
             response = Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
 
-        if (response.getStatus() != Response.Status.UNAUTHORIZED.getStatusCode())
-            Logger.error(exception);
+        // Handle logging based on response HTTP codes
+        final int status = response.getStatus();
+        // find where the exception came from
+        final StackTraceElement[] traces = exception.getStackTrace();
+        final String where;
+        if (traces.length > 0) {
+        	where = traces[0].toString();
+        } else {
+        	where = "Unknown trace location";
+        }
+        final String info = "HTTP " + status + " thrown from " + where;
+        // anything 1xx or 2xx using an Exception is weird; log as WARNING
+        if (status < 300) {
+        	Logger.warn(info);
+        }
+        // log all 3xx HTTP errors as INFO
+        if (300 <= status && status < 400) {
+        	Logger.info(info);
+        }
+        // log all 4xx HTTP errors as WARNING
+        else if (400 <= status && status < 500) {
+        	Logger.warn(info);
+        }
+        // log all other HTTP errors as ERROR; generates email by default
+        else {
+            Logger.error(info, exception);
+        }
 
         return response;
     }


### PR DESCRIPTION
The existing ICEExceptionMapper class will take every Exception thrown from a JAX-RS resource, and log an ERROR-level log (which includes an email to ICE admin) unless it is a HTTP 401 UNAUTHORIZED response.

This change makes the error handling more targeted. Any response in the HTTP 1xx and 2xx range caused by an Exception is strange, so gets logged as a WARN-level message (no email generated). A response in the HTTP 3xx range is a redirect, and so is logged as INFO message. All responses in the HTTP 4xx range -- not just the 401 UNAUTHORIZED -- get logged as WARN-level messages. This includes 403 FORBIDDEN and 404 NOT FOUND, and most importantly, as a WARN-level message, does not spam the ICE administrator with emails. The HTTP 5xx errors continue to be logged as ERROR-level messages and will by default generate emails.