### PR TITLE
Update dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,14 @@
-FROM maven:3.5 as maven
+FROM maven:3.6 as maven
 
 LABEL maintainer="William Morrell <WCMorrell@lbl.gov>"
 
-ARG ICE_VERSION=5.3.2
+ARG ICE_VERSION=5.5.2
 ARG GIT_BRANCH=master
 ARG GIT_URL=https://github.com/JBEI/ice.git
 RUN git clone --depth 1 -b "${GIT_BRANCH}" "${GIT_URL}" ice \
-    && echo "Cache busting with version ${ICE_VERSION}"
+    && git -C ice rev-parse --short HEAD > ice.hash \
+    && echo "Building ICE ${ICE_VERSION} ($(cat ice.hash))" \
+    && java -version
 
 # overwriting the git version of hibernate config
 COPY hibernate.cfg.xml /ice/src/main/resources/hibernate.cfg.xml
@@ -32,4 +34,9 @@ RUN apt-get clean && apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/tomcat/webapps/*
+
 COPY --from=maven /ice/target/ice.war /usr/local/tomcat/webapps/ROOT.war
+COPY entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["catalina.sh", "run"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ To build daily images based on the `dev` branch, use a build command similar to 
 
     docker build -t "jbei/ice:$(date "+%Y%m%d")-dev" \
         --build-arg "GIT_BRANCH=dev" \
-        --build-arg "ICE_VERSION=$(date "+%Y%m%d")"
+        --build-arg "ICE_VERSION=$(date "+%Y%m%d")" \
         .
 
 ### Launching ICE
@@ -33,4 +33,22 @@ The `docker-compose.yml` file here will launch ICE on port 9999 on the host loop
 or configuration. The default login uses `Administrator` for both the username and password.
 Launch using the command:
 
-    docker-compose up
+    docker-compose up -d
+
+### Setting HMAC authentication keys
+
+The Docker image will look for keys saved using the `docker secret` commands, and install those
+keys for use in Hash-based Message Authentication Code (HMAC) authentication to the REST API.
+If the container is launched with a `ICE_HMAC_SECRETS` environment, it will split the value on
+commas, then install keys with those names. If the name has a `:` colon character, the first
+part of the name will be the name of the Docker secret, and the second part of the name is the
+key ID used to identify the key in ICE. The following example will create an ICE service with
+keys for both EDD and DIVA, with the REST API using key IDs of `edd` and `diva`, respectively.
+
+    docker secret create edd_ice_key edd.key
+    docker secret create diva diva.key
+    docker service create \
+        -e "ICE_HMAC_SECRETS=edd_ice_key:edd,diva" \
+        --secret edd_ice_key \
+        --secret diva \
+        jbei/ice

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2.1'
+version: '3.7'
 volumes:
   postgres: {}
   index: {}
@@ -8,11 +8,20 @@ services:
   ice:
     build: .
     image: jbei/ice:latest
+    ### To allow attaching a debugger:
+    ###  1) uncomment the below command
+    ###  2) uncomment the JPDA_* environment variables
+    ###  3) uncomment the port mapping to container port 8000
+    # command: ['catalina.sh', 'jpda', 'run']
     restart: always
+    environment:
+      # JPDA_ADDRESS: "8000"
+      # JPDA_TRANSPORT: "dt_socket"
     links:
       - postgres
     ports:
       - '127.0.0.1:9999:8080'
+      # - '127.0.0.1:9000:8000'
     volumes:
       - index:/var/lib/ice/lucene
       - localdata:/usr/local/tomcat/data

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o pipefail -e
+
+# Create the rest-auth directory
+mkdir -p data/rest-auth
+# Attempt to link HMAC secrets
+while read secret
+do
+    if [ -z "${secret}" ]; then
+        break
+    fi
+    src_secret="${secret%%:*}"
+    tgt_secret="${secret#*:}"
+    if [ ! -r "/run/secrets/${src_secret}" ]; then
+        echo "Cannot read secret ${src_secret}!"
+    elif [ -f "data/rest-auth/${tgt_secret}" ]; then
+        echo "REST HMAC key ${secret#*:} already exists!"
+    else
+        ln -s "/run/secrets/${src_secret}" "data/rest-auth/${tgt_secret}"
+    fi
+done < <(echo "${ICE_HMAC_SECRETS}" | tr ',' '\n')
+
+exec "$@"

--- a/src/main/java/org/jbei/ice/lib/parsers/sbol/SBOLParser.java
+++ b/src/main/java/org/jbei/ice/lib/parsers/sbol/SBOLParser.java
@@ -17,6 +17,7 @@ import org.jbei.ice.storage.model.Account;
 import org.jbei.ice.storage.model.Entry;
 import org.jbei.ice.storage.model.Part;
 import org.jbei.ice.storage.model.Sequence;
+import org.sbolstandard.core2.Module;  // specific callout to avoid clash with java.lang.Module
 import org.sbolstandard.core2.*;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
Updating the Dockerfile versions and adding an entrypoint script.

Building with the `maven:3.5` image was failing because of something weird with the default test runner configs, and the solution to the failure is to use an updated JDK. Since the build is happening with a Java 11 JDK now, there was one small change needed in the SBOL parser, because a star import was causing a name clash between `java.lang.Module` (new in Java 9) and `org.sbolstandard.core2.Module`. Fix is just explicitly importing the SBOL `Module` class instead of depending on star import.

While updating the Dockerfile, also adding an entrypoint script that helps to auto-configure ICE when it's launched in Docker with EDD.