### PR TITLE
Pluggable auth

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN sed -i.bak -E \
         /tmp/src/main/webapp/WEB-INF/web.xml \
     && rm /tmp/src/main/webapp/WEB-INF/web.xml.bak \
     && cp /tmp/docker/hibernate.cfg.xml /tmp/src/main/resources/hibernate.cfg.xml \
+    && cp /tmp/docker/logback.xml /tmp/src/main/resources/logback.xml \
     && mvn -DskipTests=true package
 
 # -----

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i.bak -E \
 
 # -----
 
-FROM tomcat:9-jdk16
+FROM tomcat:9-jdk17
 
 RUN apt-get clean \
     && apt-get update \

--- a/docker/logback.xml
+++ b/docker/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.jbei.ice" level="INFO"/>
+    <logger name="org.jbei.auth" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Takes care of two things that are in Steve's document on deploying ICE.

1. Alter the logback.xml configuration for containers. The document describes changing the location of the logfile; while the Docker container eschews logging to a file at all, and sends everything to `stdout`.
2. Alter the authentication backend. The document says to manually switch out the line with `new LocalAuthentication()` to instead use the correct backend for the deployment. It could be `new LblLdapAuthentication()` for using at LBL, or whatever class is used for JGI's custom authentication portal. Rather than making code changes at every deploy, I'm resurrecting a code change I submitted in 2015, that loads the correct class to use from the database.

NOTE: every existing deploy will fall back to using the default `LocalAuthentication` class, until the setting is updated. Please, in the future, when doing debugging: do *not* hard code `UserIdAuthentication` and take out the pluggable code again. Choosing the auth backend should be a setting, and not require code changes.